### PR TITLE
(fix) cleanup dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,9 +3,6 @@
   :url "https://bearychat.com/"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [clj-http "1.0.1" :exclusions [org.clojure/tools.reader]]
-                 [cheshire "5.4.0"]
-                 [riemann "0.2.10-SNAPSHOT"]]
-  )
-
+  :dependencies [[org.clojure/clojure "1.6.0"]]
+  :profiles {:provided
+             {:dependencies [[riemann "0.2.10"]]}})


### PR DESCRIPTION
Framework dependencies should be marked as :provided so it won't be
packaged into the uberjar. If we package those jars into uberjar, there
might be risk for a version conflict.
